### PR TITLE
Bind mount host's /dev to container's /dev

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -129,6 +129,11 @@ const createContainer = (docker, image, splashImage, dockerPort, proxy, edisonFo
   const mounts = []
   return docker.version()
   .then((version) => {
+    if (os.platform() === 'linux') {
+      // In some situations, devices created by `losetup -f` in the container only appear on the host and not in the container.
+      // See https://github.com/balena-io/balena-cli/issues/1008
+      mounts.push(bindMount('/dev', '/dev', version.ApiVersion))
+    }
     if (splashImage) {
       mounts.push(bindMount(splashImage, SPLASH_IMAGE_PATH_IN_DOCKER, version.ApiVersion))
     }


### PR DESCRIPTION
This fixes an issue with loop devices only appearing on the host in some
situations. See https://github.com/balena-io/balena-cli/issues/1008 .

Change-type: patch