### PR TITLE
Don't try to pin releases when supervisor is < 7.0.0

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -655,6 +655,9 @@ class Preloader extends EventEmitter {
 
   _getAppData () {
     if (this._supervisorLT7()) {
+      if (this.pinDevice === true) {
+        throw new this.balena.errors.BalenaError('Pinning releases only works with supervisor versions >= 7.0.0')
+      }
       // Add an appId to each app from state v1 (the supervisor needs it)
       // rename environment -> env
       // rename image -> imageId

--- a/src/preload.py
+++ b/src/preload.py
@@ -518,6 +518,10 @@ def docker_context_manager(storage_driver, mountpoint):
 
 def write_resin_device_pinning(app_data, output):
     """Create resin-device-pinnnig.json to hold pinning information"""
+    if type(app_data) != dict:
+        # app_data is a list when the supervisor version is < 7.0.0,
+        # pinning is not suported on these.
+        return
     if not app_data.get("pinDevice", False):
         return
     apps = app_data.get("apps", {})


### PR DESCRIPTION
When the supervisor is < 7.0.0, appData is a list and the python script fails with
```
  File "/usr/src/app/preload.py", line 821, in <module>
    result = method(**data.get("parameters", {}))
  File "/usr/src/app/preload.py", line 766, in main_preload
    mountpoint + "/etc/resin-device-pinning.conf"
  File "/usr/src/app/preload.py", line 521, in write_resin_device_pinning
    if not app_data.get("pinDevice", False):
AttributeError: 'list' object has no attribute 'get'
```

It won't work anyway, so this commit adds a warning when `--pinDevice` is specified for an image that has an old supervisor and ignores `app_data` when it's not a `dict` in `preload.py`.

Change-type: patch