### PR TITLE
When checking supervisor version strip logstream ending too

### DIFF
--- a/src/preload.py
+++ b/src/preload.py
@@ -655,6 +655,7 @@ def _get_images_and_supervisor_version(image=None):
                 if match(SUPERVISOR_REPOSITORY_RE, repository):
                     if version != "latest":
                         supervisor_version = version.lstrip("v")
+                        supervisor_version = version.rstrip("_logstream")
                 else:
                     images.add(repository)
             return list(images), supervisor_version


### PR DESCRIPTION
Some supervisors have `vX.Y.Z` and some `vX.Y.Z_logstream` entries, and all should fall back in the version check to the basic `X.Y.Z` values.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>